### PR TITLE
Overwrite app editor if no whoops editor config was found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `laravel-whoops-editor` will be documented in this file.
 
+## [3.0.0] - 2017-12-15
+
+### Fixed
+
+- Use default config if `whoops-editor.editors` not found
+- PHP 7.0 support
+
+### Changed
+
+- `resolveEditor` method not require config argument
+- `resolveFilePath` method not require config argument
+
 ## [2.0.0] - 2017-12-15
 
 ### Added
@@ -20,4 +32,5 @@ All notable changes to `laravel-whoops-editor` will be documented in this file.
 - Linux support for IntelliJ IDEA
 - Linux support for SublimeText
 
+[3.0.0]: https://github.com/cybercog/laravel-whoops-editor/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/cybercog/laravel-whoops-editor/compare/1.0.0...2.0.0

--- a/src/Providers/WhoopsEditorServiceProvider.php
+++ b/src/Providers/WhoopsEditorServiceProvider.php
@@ -32,7 +32,7 @@ class WhoopsEditorServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot(): void
+    public function boot()
     {
         $this->registerPublishes();
         $this->overwriteAppConfig();
@@ -43,7 +43,7 @@ class WhoopsEditorServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register(): void
+    public function register()
     {
         $this->configure();
     }
@@ -53,7 +53,7 @@ class WhoopsEditorServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function configure(): void
+    protected function configure()
     {
         $this->mergeConfigFrom(
             __DIR__ . '/../../config/whoops-editor.php', 'whoops-editor'
@@ -65,7 +65,7 @@ class WhoopsEditorServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerPublishes(): void
+    protected function registerPublishes()
     {
         $this->publishes([
             __DIR__ . '/../../config/whoops-editor.php' => config_path('whoops-editor.php'),
@@ -93,7 +93,7 @@ class WhoopsEditorServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function overwriteAppConfig(): void
+    protected function overwriteAppConfig()
     {
         $this->config = $this->app->make('config');
         $editor = $this->resolveEditor();

--- a/tests/Unit/Providers/WhoopsEditorServiceProviderTest.php
+++ b/tests/Unit/Providers/WhoopsEditorServiceProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Laravel Whoops Editor.
+ *
+ * (c) Anton Komarev <a.komarev@cybercog.su>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cog\Tests\Laravel\WhoopsEditor\Unit\Providers;
+
+use Cog\Tests\Laravel\WhoopsEditor\TestCase;
+
+/**
+ * Class WhoopsEditorServiceProviderTest.
+ *
+ * @package Cog\Tests\Laravel\WhoopsEditor\Unit\Providers
+ */
+class WhoopsEditorServiceProviderTest extends TestCase
+{
+    /** @var \Illuminate\Contracts\Config\Repository */
+    private $config;
+
+    protected function setUp()
+    {
+        putenv('APP_EDITOR=test');
+
+        parent::setUp();
+
+        $this->config = $this->app->make('config');
+    }
+
+    /** @test  */
+    public function it_loads_package_config()
+    {
+        $this->assertNotEmpty($this->config->get('whoops-editor'));
+    }
+
+    /** @test  */
+    public function it_gets_package_whoops_editor_variable_from_environment()
+    {
+        $editor = $this->config->get('whoops-editor.editor');
+
+        $this->assertSame('test', $editor);
+    }
+
+    /** @test  */
+    public function it_overwrites_app_editor_with_environment_value()
+    {
+        $editor = $this->config->get('app.editor');
+
+        $this->assertSame('test', $editor);
+    }
+}


### PR DESCRIPTION
Fixes issue when `app.editor` equal to `null` and `APP_EDITOR` environment variable is specified, but this editor not found in `whoops-editor.editors` list.

Additionally it removes `void` return types since they are introduced in PHP 7.1.